### PR TITLE
🧾 Project Summary – Discord Invite Bot with Role Auto-Assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
+# Use official Python image
 FROM python:3.11-slim
 
+# Set working directory inside container
 WORKDIR /app
 
+# Install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Copy the bot code and env files into the container
 COPY . .
 
+# Run the bot
 CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -24,3 +24,35 @@ This is a lightweight Discord bot built with `discord.py` that:
 ```bash
 git clone https://github.com/youruser/discord-role-bot.git
 cd discord-role-bot
+---
+
+## 🧪 Deployment Instructions
+
+### 1. Setup
+
+Create a `.env` file in the root directory:
+
+```env
+DISCORD_TOKEN=your_discord_token_here
+GUILD_ID=your_discord_guild_id
+```
+
+### 2. Build and Run with Docker
+
+```bash
+docker build -t discord-role-bot .
+docker run --env-file .env -v $(pwd)/data:/app --name rolebot discord-role-bot
+```
+
+### 3. Or Use Docker Compose
+
+```bash
+docker compose up -d
+```
+
+### 4. Usage
+
+- `!setaccessrole @RoleName` — Sets the role to assign
+- `!generateinvite` — Generates a permanent invite link
+
+Users (new or existing) who use the invite will receive the set role.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  discord-bot:
+    build: .
+    container_name: discord_role_bot
+    env_file: .env
+    volumes:
+      - ./data:/app
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.8'
-
 services:
   discord-bot:
-    build: .
+    build:
+      context: .  # 👈 must be the folder where bot.py is
     container_name: discord_role_bot
     env_file: .env
     volumes:
-      - ./data:/app
+      - ./data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
📌 Objective

Build a Discord bot that:
	•	Allows an admin to set a role (/setrole)
	•	Generates a permanent invite link (/createinvite)
	•	When a user (new or existing) clicks the invite:
	•	If new to the server → role is assigned on join
	•	If already in the server → they can use /getaccess to self-assign the role

All functionality runs in a Docker container for ease of deployment.

⸻

🛠️ Key Features Implemented
	•	Slash Commands via discord.app_commands:
	•	/setrole [@Role] → Stores role ID in access_role.txt
	•	/createinvite → Creates a non-expiring invite and stores it in permanent_invite.txt
	•	/getaccess → Assigns role to the user invoking it, if they used the invite
	•	Event Listeners:
	•	on_ready → Confirms bot is running, syncs slash commands
	•	on_member_join → Assigns role to new members if they joined via the invite
	•	Persistent Files:
	•	access_role.txt → Stores the role ID
	•	permanent_invite.txt → Stores the invite code

⸻

🐳 Docker Setup
	•	Docker containerized for easy deployment
	•	Uses python:3.11-slim image
	•	bot.py auto-runs inside container
	•	Environment variables passed via .env:
	DISCORD_TOKEN=your_bot_token
GUILD_ID=your_server_id

•	Includes:
	•	Dockerfile
	•	docker-compose.yml
	•	.env file (user-provided)

⸻

🧪 Testing & Issues Encountered
	•	Bot failed to run initially due to:
	•	bot.py missing in Docker context
	•	Missing or incorrect ROLE_ID env var
	•	Added persistent files for role/invite to eliminate dependency on environment variables
	•	New members successfully received role on join
	•	Existing members needed a manual command to get the role — led to addition of /getaccess

⸻

🔒 Permissions & Intents
	•	Required intents:
	•	Server Members Intent (enabled in the Discord Developer Portal)
	•	Bot permissions integer: 1101927549953

📦 Next Steps
	•	Optional: Track which invite each user joined from
	•	Optional: Allow invite expiration or single-use tokens
	•	Optional: Web dashboard for managing roles and invites

Let me know if you want this saved into a README.md, zipped, or packaged with the bot.