### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
         id: vars
         run: |
           echo "DATE_TAG=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
-          echo "IMAGE=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          echo "IMAGE=ghcr.io/${{ github.repository_owner }}/discord_invite_bot" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow (build.yml) that automates building and publishing a Docker image for the bot. The workflow runs on every push to the main branch and can also be manually triggered. It builds the image using Docker Buildx and pushes it to the GitHub Container Registry under the personal user namespace (ghcr.io/wickedyoda/discord_invite_bot) with both latest and date-based tags.