### PR TITLE
Add modal-based code entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 This bot allows select Discord users to create **role-bound invite links** and **6-digit access codes** that assign roles automatically to new or existing users. The system supports slash commands and permission control via role checks.
 
 ---
-=======
-# Discord Invite Role Bot
-
-This bot manages invite-based and code-based role assignments within a Discord server. Designed to run in Docker and pull its image from GitHub Container Registry.
 
 ## 💡 Features
 
@@ -19,12 +15,11 @@ This bot manages invite-based and code-based role assignments within a Discord s
     - Users joining through the invite.
     - Existing users who submit the generated code via `/enter_role`.
 
-
-- Slash command `/enter_role <code>`:
-  - Allows members to claim a role by entering the 6-digit code.
+- Slash command `/enter_role`:
+  - Prompts the user for a 6-digit code and assigns the matching role.
 
 - `/submitrole`: Submit a role, get an invite and access code.
-- `/enter_role <code>`: Enter a 6-digit code to receive the corresponding role.
+- `/enter_role`: Enter the 6-digit code to receive the corresponding role.
 - `/getaccess`: Public command to assign a preconfigured access role.
 - Only users with the **Employee** role can run role-submitting commands.
 - **Admins** and **Gl.iNet Moderators** get full access to manage all bot commands.
@@ -47,11 +42,9 @@ The bot will:
 
 ### ➤ 2. Role Access by Code
 
-Any member can type:
-```
-/enter_role <6-digit-code>
-```
-The bot checks if the code is valid and assigns the associated role.
+Any member can type `/enter_role`. The bot will prompt them privately for the
+6-digit code. After they submit it, the bot assigns the associated role if the
+code is valid.
 
 ### ➤ 3. Automatic Role Assignment via Invite
 
@@ -155,7 +148,6 @@ See [`CHANGELOG.md`](./CHANGELOG.md) for a history of updates and improvements.
 Created and maintained by [WickedYoda](https://wickedyoda.com)
 
 For advanced support, join WickedYoda's Discord https://discord.gg/m6UjX6UhKe
-=======
 - Slash command `/getaccess`:
   - Assigns a single configured role to the user.
   - Usable by all members.

--- a/bot.py
+++ b/bot.py
@@ -91,21 +91,33 @@ async def submitrole(interaction: discord.Interaction):
         print("Error in /submitrole:", e)
         await interaction.followup.send("❌ Something went wrong. Try again.", ephemeral=True)
 
-@tree.command(name="enter_role", description="Enter a 6-digit code to receive a role", guild=discord.Object(id=GUILD_ID))
-@app_commands.describe(code="The 6-digit code provided to you")
-async def enter_role(interaction: discord.Interaction, code: str):
-    role_id = get_role_id_by_code(code)
-    if not role_id:
-        await interaction.response.send_message("❌ Invalid code.", ephemeral=True)
-        return
+class CodeEntryModal(discord.ui.Modal, title="Enter Role Code"):
+    code = discord.ui.TextInput(label="6-digit code", min_length=6, max_length=6)
 
-    role = interaction.guild.get_role(role_id)
-    if not role:
-        await interaction.response.send_message("❌ Role not found.", ephemeral=True)
-        return
+    async def on_submit(self, interaction: discord.Interaction):
+        role_id = get_role_id_by_code(self.code.value.strip())
+        if not role_id:
+            await interaction.response.send_message("❌ Invalid code.", ephemeral=True)
+            return
 
-    await interaction.user.add_roles(role)
-    await interaction.response.send_message(f"✅ You've been given the **{role.name}** role!", ephemeral=True)
+        role = interaction.guild.get_role(role_id)
+        if not role:
+            await interaction.response.send_message("❌ Role not found.", ephemeral=True)
+            return
+
+        await interaction.user.add_roles(role)
+        await interaction.response.send_message(
+            f"✅ You've been given the **{role.name}** role!", ephemeral=True
+        )
+
+
+@tree.command(
+    name="enter_role",
+    description="Enter a 6-digit code to receive a role",
+    guild=discord.Object(id=GUILD_ID),
+)
+async def enter_role(interaction: discord.Interaction):
+    await interaction.response.send_modal(CodeEntryModal())
 
 @tree.command(name="getaccess", description="Assign yourself the protected role", guild=discord.Object(id=GUILD_ID))
 async def getaccess(interaction: discord.Interaction):

--- a/change.md
+++ b/change.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Implement admin-only invite cleanup feature (planned)
 - Add web dashboard for role/code management (planned)
+- `/enter_role` now opens a private modal for the 6-digit code
 
 ---
 


### PR DESCRIPTION
## Summary
- simplify README
- handle `/enter_role` with a modal prompt so codes aren't shown in chat
- document modal-based flow in change log

## Testing
- `python -m py_compile bot.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6877fb4cf7d88323818758f53cd31a8e