### PR TITLE
Add beta branch Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish-beta.yml
+++ b/.github/workflows/docker-publish-beta.yml
@@ -1,0 +1,43 @@
+name: Build and Publish Docker image (beta)
+# Triggers on pushes to beta branch or manual dispatch
+
+on:
+  push:
+    branches:
+      - beta
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare variables
+        id: vars
+        run: |
+          echo "DATE_TAG=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+          echo "IMAGE=ghcr.io/${{ github.actor }}/discord_invite_bot" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.IMAGE }}:beta
+            ${{ steps.vars.outputs.IMAGE }}:beta-${{ steps.vars.outputs.DATE_TAG }}
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish Docker images from the `beta` branch
- allow manual runs for the `beta` Docker workflow

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py 1.bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687830fd84408323a8a02af53a5fafaa