### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wickedyoda/discord_invite_bot/security/code-scanning/4](https://github.com/wickedyoda/discord_invite_bot/security/code-scanning/4)

To fix the issue, explicitly define a `permissions` block in the workflow to limit the `GITHUB_TOKEN`'s access to the minimal set of permissions required. In this case, the workflow appears to require `contents: read` for repository content access and possibly `packages: write` to push the Docker image to the GitHub Container Registry (`ghcr.io`). 

The `permissions` block should be added at the root level of the workflow file, as it applies to all jobs unless overridden at the job level. This ensures that the principle of least privilege is adhered to across the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
