### PR TITLE
Improve invite tracking and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ services:
     environment:
       - DISCORD_TOKEN=your_discord_token
       - GUILD_ID=your_guild_id
+      - GENERAL_CHANNEL_ID=general_channel_id
+      - LOG_LEVEL=INFO
     volumes:
       - ./data:/app/data
 ```
 
-> 📁 Create a `data/` folder to persist files like `access_role.txt` and `role_codes.txt`.
-> These files are stored inside `/app/data` in the container.
+> 📁 Create a `data/` folder to persist files like `access_role.txt`, `role_codes.txt`, and `invite_roles.json`.
+> A log file `bot.log` will also be written to this folder.
 
 To start:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py==2.3.2
 python-dotenv==1.0.1
+


### PR DESCRIPTION
## Summary
- track invite to role mapping and automatic role assignment
- log to `data/bot.log` and allow setting `LOG_LEVEL`
- support configurable general channel for invites
- document new environment variables
- clean up `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_688294a76c308323866b551d67ba39b6