### PR TITLE
Fix load_invite_roles usage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -44,13 +44,6 @@ bot = commands.Bot(command_prefix='!', intents=intents)
 tree = bot.tree
 
 
-# Runtime caches for invite tracking
-invite_roles = load_invite_roles()
-invite_uses = {}
-
-beta
-
-beta
 def generate_code():
     while True:
         code = ""


### PR DESCRIPTION
## Summary
- remove premature call to `load_invite_roles`

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6882a0f734a083238538354cb3fb6641